### PR TITLE
Update to community.docker.docker_compose_v2

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,13 +1,13 @@
 ---
 
 - name: Compose down
-  community.docker.docker_compose:
+  community.docker.docker_compose_v2:
     project_src: /opt/dockge
     project_name: dockge
     state: absent
 
 - name: Compose up
-  community.docker.docker_compose:
+  community.docker.docker_compose_v2:
     project_src: /opt/dockge
     project_name: dockge
     state: present


### PR DESCRIPTION
ERROR! [DEPRECATED]: community.docker.docker_compose has been removed. This module uses docker-compose v1, which is End of Life since July 2022. Please migrate to community.docker.docker_compose_v2. This feature was removed from community.docker in version 4.0.0. Please update your playbooks.